### PR TITLE
Initial rpc primitive and handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
+ "frontier-rpc-primitives",
  "pallet-aura",
  "pallet-balances",
  "pallet-ethereum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,8 +1110,10 @@ dependencies = [
 name = "frontier-template-node"
 version = "2.0.0-dev"
 dependencies = [
+ "frontier-rpc",
  "frontier-template-runtime",
  "futures 0.3.5",
+ "jsonrpc-core",
  "log",
  "pallet-evm",
  "parking_lot 0.10.2",
@@ -1123,6 +1125,7 @@ dependencies = [
  "sc-executor",
  "sc-finality-grandpa",
  "sc-network",
+ "sc-rpc",
  "sc-service",
  "sc-transaction-pool",
  "sp-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,9 +1073,13 @@ version = "0.1.0"
 dependencies = [
  "ethereum-types",
  "frontier-rpc-core",
+ "frontier-rpc-primitives",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,10 @@ dependencies = [
 name = "frontier-rpc-primitives"
 version = "0.1.0"
 dependencies = [
+ "ethereum",
+ "ethereum-types",
  "sp-api",
+ "sp-std",
 ]
 
 [[package]]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,4 +11,8 @@ jsonrpc-core = "14.0.3"
 jsonrpc-derive = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 ethereum-types = "0.9.0"
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../vendor/substrate/primitives/api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../vendor/substrate/primitives/runtime" }
+sp-blockchain = { version = "2.0.0-dev", default-features = false, path = "../vendor/substrate/primitives/blockchain" }
 frontier-rpc-core = { path = "./core" }
+frontier-rpc-primitives = { path = "./primitives" }

--- a/rpc/primitives/Cargo.toml
+++ b/rpc/primitives/Cargo.toml
@@ -6,11 +6,20 @@ edition = "2018"
 description = "Runtime primitives for Ethereum RPC (web3) compatibility layer for Substrate."
 license = "GPL-3.0"
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
+ethereum = { version = "0.2", default-features = false}
+ethereum-types = { version = "0.9", default-features = false}
 sp-api = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/std" }
 
 [features]
 default = ["std"]
 std = [
+	"ethereum/std",
+	"ethereum-types/std",
 	"sp-api/std",
+	"sp-std/std",
 ]

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -1,6 +1,84 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_std::prelude::*;
+use ethereum_types::{H160, H256, U256};
+
+use ethereum::{Block as EthBlock, Account as EthAccount};
+
 sp_api::decl_runtime_apis! {
 	/// API necessary for Ethereum-compatibility layer.
-	pub trait EthereumApi {
+	pub trait EthRuntimeApi {
+		// eth_gasPrice
+		/// pallet_evm::FeeCalculator::min_gas_price()
+		fn min_gas_price() -> U256;
 
+		// eth_accounts
+		/// <pallet_evm::Module<T>>::accounts()
+		/// The list of keys in the EVM pallet Accounts StorageMap.
+		fn evm_accounts() -> Vec<H160>;
+
+		// eth_blockNumber
+		/// <frame_system::Module<T>>::block_number()
+		fn current_block_number() -> u32;
+
+		// eth_getBalance
+		/// <pallet_evm::Module<T>>::accounts(H160), pallet_evm::backend::Account.balance.
+		/// The Account struct is part of the EVM pallet and has a balance field.
+		fn account_balance(_: H160) -> U256;
+
+		// eth_getBlockByHash
+		/// ethereum::Block in <pallet_evm::Module<T>>::BlocksAndReceipts
+		/// Requires conversion from Block::Hash to BlockNumber.
+		// fn block_by_hash(_: Block::Hash) -> EthBlock;
+
+		// eth_getBlockByNumber
+		// ethereum::Block in <pallet_evm::Module<T>>::BlocksAndReceipts
+		// fn block_by_number(_: u32) -> EthBlock;
+
+		// eth_getTransactionCount
+		/// This requires previous conversion from 'latest','earliest','pending' to BlockNumber.
+		/// Is this up to BlockNumber or in the specified BlockNumber?
+		fn address_transaction_count(_: H160, _: u32) -> U256;
+
+		// eth_getBlockTransactionCountByHash
+		fn transaction_count_by_hash(_: H160) -> U256;
+
+		// eth_getBlockTransactionCountByNumber
+		fn transaction_count_by_number(_: u32) -> U256;
+
+		// eth_getCode
+		/// This should be in pallet_evm::backend::Account,
+		/// but the field is not implemented?
+		fn bytecode_from_address(_: H160, _: u32) -> Vec<u8>;
+
+		// eth_sendRawTransaction and eth_submitTransaction
+		// <pallet_ethereum::Module<T>>::execute()?
+		fn execute(_: Vec<u8>) -> H256;
+
+		// eth_call
+		// /// <pallet_evm::Module<T>>::execute_call()?
+		// fn execute_call(_: CallRequest, _: u32) -> Vec<u8>;
+
+		// eth_estimateGas
+		// /// Requires source bytecode gas conversion table. Didn't find a reference in the pallet_evm.
+		// /// Related to the EVM crate https://github.com/sorpaas/rust-evm/blob/master/src/executor/stack.rs#L746
+		// fn virtual_call(_: CallRequest, _: u32) -> U256;
+
+		// // eth_getTransactionByHash
+		// // TODO no StorageMap by ethereum::transaction::Transaction Hash.
+		// fn transaction_by_hash(_: H256) -> Transaction;
+
+		// // eth_getTransactionByBlockHashAndIndex
+		// /// ethereum::Block.transactions[Index] in <pallet_evm::Module<T>>::BlocksAndReceipts
+		// /// Requires conversion from Block::Hash to BlockNumber.
+		// fn transaction_by_block_hash(_: H256, _: Index) -> Transaction;
+
+		// // eth_getTransactionByBlockNumberAndIndex
+		// /// ethereum::Block.transactions[Index] in <pallet_evm::Module<T>>::BlocksAndReceipts
+		// fn transaction_by_block_number(_: H256, _: Index) -> Transaction;
+
+		// // eth_getTransactionReceipt
+		// // TODO no StorageMap by ethereum::transaction::Transaction Hash.
+		// fn transaction_receipt(_: H256) -> Receipt;
 	}
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,18 +1,45 @@
+/// EthApi service handler.
+/// 
+/// All calls to client.runtime.api expect a block hash reference parameter.
+/// For example:
+/// 
+/// 	let api = self.client.runtime_api();
+/// 	let at = BlockId::hash(self.client.info().best_hash);
+/// 	api.min_gas_price(&at).map_err(...)
+use std::sync::Arc;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{generic::BlockId, traits::{Block as BlockT}};
+use sp_api::ProvideRuntimeApi;
 use ethereum_types::{H160, H256, H64, U256, U64};
-use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_core::{Result,BoxFuture};
 
-use frontier_rpc_core::EthApi;
+
+pub use frontier_rpc_core::EthApi;
+pub use frontier_rpc_primitives::EthRuntimeApi;
 use frontier_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, EthAccount, Filter, Index, Log, Receipt, RichBlock,
 	SyncStatus, Transaction, Work,
 };
-
 pub use frontier_rpc_core::EthApiServer;
 
-pub struct EthRpcImpl;
+pub struct EthHandler<C, P> {
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
+}
 
-impl EthApi for EthRpcImpl {
-	/// Returns protocol version encoded as a string (quotes are necessary).
+impl<C, P> EthHandler<C, P> {
+	pub fn new(client: Arc<C>) -> Self {
+		EthHandler { client, _marker: Default::default() }
+	}
+}
+
+impl<C, Block> EthApi
+	for EthHandler<C, Block>
+where
+	Block: BlockT,
+	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	C::Api: EthRuntimeApi<Block>
+{
 	fn protocol_version(&self) -> Result<String> {
 		return Ok("0x54".to_string());
 	}
@@ -36,19 +63,22 @@ impl EthApi for EthRpcImpl {
 	fn chain_id(&self) -> Result<Option<U64>> {
 		unimplemented!("chain_id");
 	}
-
+	/// client.runtime.api.min_gas_price
 	fn gas_price(&self) -> BoxFuture<U256> {
 		unimplemented!("gas_price");
 	}
 
+	/// client.runtime.api.evm_accounts
 	fn accounts(&self) -> Result<Vec<H160>> {
 		unimplemented!("accounts");
 	}
 
+	/// client.runtime.api.current_block_number
 	fn block_number(&self) -> Result<U256> {
 		unimplemented!("block_number");
 	}
 
+	/// client.runtime.api.account_balance
 	fn balance(&self, _: H160, _: Option<BlockNumber>) -> BoxFuture<U256> {
 		unimplemented!("balance");
 	}
@@ -61,22 +91,27 @@ impl EthApi for EthRpcImpl {
 		unimplemented!("storage_at");
 	}
 
+	/// client.runtime.api.block_by_hash
 	fn block_by_hash(&self, _: H256, _: bool) -> BoxFuture<Option<RichBlock>> {
 		unimplemented!("block_by_hash");
 	}
 
+	/// client.runtime.api.block_by_number
 	fn block_by_number(&self, _: BlockNumber, _: bool) -> BoxFuture<Option<RichBlock>> {
 		unimplemented!("block_by_number");
 	}
 
+	/// client.runtime.api.address_transaction_count
 	fn transaction_count(&self, _: H160, _: Option<BlockNumber>) -> BoxFuture<U256> {
 		unimplemented!("transaction_count");
 	}
 
+	/// client.runtime.api.transaction_count_by_hash
 	fn block_transaction_count_by_hash(&self, _: H256) -> BoxFuture<Option<U256>> {
 		unimplemented!("block_transaction_count_by_hash");
 	}
 
+	/// client.runtime.api.transaction_count_by_number
 	fn block_transaction_count_by_number(&self, _: BlockNumber) -> BoxFuture<Option<U256>> {
 		unimplemented!("block_transaction_count_by_number");
 	}
@@ -89,30 +124,37 @@ impl EthApi for EthRpcImpl {
 		unimplemented!("block_uncles_count_by_number");
 	}
 
+	/// client.runtime.api.bytecode_from_address
 	fn code_at(&self, _: H160, _: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		unimplemented!("code_at");
 	}
 
+	/// client.runtime.api.execute
 	fn send_raw_transaction(&self, _: Bytes) -> Result<H256> {
 		unimplemented!("send_raw_transaction");
 	}
 
+	/// client.runtime.api.execute
 	fn submit_transaction(&self, _: Bytes) -> Result<H256> {
 		unimplemented!("submit_transaction");
 	}
 
+	/// client.runtime.api.execute_call
 	fn call(&self, _: CallRequest, _: Option<BlockNumber>) -> BoxFuture<Bytes> {
 		unimplemented!("call");
 	}
 
+	/// client.runtime.api.virtual_call
 	fn estimate_gas(&self, _: CallRequest, _: Option<BlockNumber>) -> BoxFuture<U256> {
 		unimplemented!("estimate_gas");
 	}
 
+	/// client.runtime.api.transaction_by_hash
 	fn transaction_by_hash(&self, _: H256) -> BoxFuture<Option<Transaction>> {
 		unimplemented!("transaction_by_hash");
 	}
 
+	/// client.runtime.api.transaction_by_block_hash
 	fn transaction_by_block_hash_and_index(
 		&self,
 		_: H256,
@@ -121,6 +163,7 @@ impl EthApi for EthRpcImpl {
 		unimplemented!("transaction_by_block_hash_and_index");
 	}
 
+	/// client.runtime.api.transaction_by_block_number
 	fn transaction_by_block_number_and_index(
 		&self,
 		_: BlockNumber,
@@ -129,6 +172,7 @@ impl EthApi for EthRpcImpl {
 		unimplemented!("transaction_by_block_number_and_index");
 	}
 
+	/// client.runtime.api.transaction_receipt
 	fn transaction_receipt(&self, _: H256) -> BoxFuture<Option<Receipt>> {
 		unimplemented!("transaction_receipt");
 	}

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -13,12 +13,14 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+jsonrpc-core = "14.0.3"
 futures = "0.3.4"
 log = "0.4.8"
 structopt = "0.3.8"
 parking_lot = "0.10.0"
 
 sc-cli = { version = "0.8.0-dev", path = "../../vendor/substrate/client/cli" }
+sc-rpc = { version = "2.0.0-dev", path = "../../vendor/substrate/client/rpc" }
 sp-core = { version = "2.0.0-dev", path = "../../vendor/substrate/primitives/core" }
 sc-executor = { version = "0.8.0-dev", path = "../../vendor/substrate/client/executor" }
 sc-service = { version = "0.8.0-dev", path = "../../vendor/substrate/client/service" }
@@ -38,6 +40,7 @@ sp-runtime = { version = "2.0.0-dev", path = "../../vendor/substrate/primitives/
 sc-basic-authorship = { path = "../../vendor/substrate/client/basic-authorship" }
 
 frontier-template-runtime = { version = "2.0.0-dev", path = "../runtime" }
+frontier-rpc = { version = "0.1.0", path = "../../rpc" }
 
 [build-dependencies]
 substrate-build-script-utils = { version = "2.0.0-dev", path = "../../vendor/substrate/utils/build-script-utils" }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -39,6 +39,8 @@ sp-std = { version = "2.0.0-dev", default-features = false, path = "../../vendor
 sp-transaction-pool = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/transaction-pool" }
 sp-version = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/version" }
 
+frontier-rpc-primitives = { version = "0.1.0", default-features = false, path = "../../rpc/primitives" }
+
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../vendor/substrate/utils/wasm-builder-runner" }
 
@@ -71,4 +73,5 @@ std = [
 	"transaction-payment/std",
 	"ethereum/std",
 	"evm/std",
+	"frontier-rpc-primitives/std",
 ]

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -12,7 +12,7 @@ use grandpa::fg_primitives;
 use grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, U256};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::traits::{
 	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Saturating, Verify,
 };
@@ -431,6 +431,44 @@ impl_runtime_apis! {
 			// defined our key owner proof type as a bottom type (i.e. a type
 			// with no values).
 			None
+		}
+	}
+
+	impl frontier_rpc_primitives::EthRuntimeApi<Block> for Runtime {
+		fn min_gas_price() -> U256 {
+			U256::zero()
+		}
+
+		fn evm_accounts() -> Vec<H160> {
+			vec![H160::zero()]
+		}
+
+		fn current_block_number() -> u32 {
+			0 as u32
+		}
+
+		fn account_balance(_: H160) -> U256 {
+			U256::zero()
+		}
+
+		fn address_transaction_count(_: H160, _: u32) -> U256 {
+			U256::zero()
+		}
+
+		fn transaction_count_by_hash(_: H160) -> U256 {
+			U256::zero()
+		}
+
+		fn transaction_count_by_number(_: u32) -> U256 {
+			U256::zero()
+		}
+
+		fn bytecode_from_address(_: H160, _: u32) -> Vec<u8> {
+			vec![0 as u8]
+		}
+
+		fn execute(_: Vec<u8>) -> H256 {
+			H256::zero()
 		}
 	}
 }


### PR DESCRIPTION
* Add initial supported methods to `decl_runtime_apis`.
* Add handler to `rpc` module.
* Add rpc extension to `service`.
* _Zero_ impl for `impl_runtime_apis`.
* Add example of boxed future `DispatchFutureResult` to `rpc`.