### PR TITLE
Fix pallet-ethereum auxstore bug

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -279,17 +279,8 @@ impl<T: Trait> Module<T> {
 		}
 
 		CurrentBlock::put(block.clone());
-		if receipts.len() > 0 {
-			CurrentReceipts::put(receipts.clone());
-		} else {
-			CurrentReceipts::kill();
-		}
-
-		if statuses.len() > 0 {
-			CurrentTransactionStatuses::put(statuses.clone());
-		} else {
-			CurrentTransactionStatuses::kill();
-		}
+		CurrentReceipts::put(receipts.clone());
+		CurrentTransactionStatuses::put(statuses.clone());
 
 		let digest = DigestItem::<T::Hash>::Consensus(
 			FRONTIER_ENGINE_ID,


### PR DESCRIPTION
Remove WIP auxstore draft from pallet-ethereum that causes a bug on retrivieng blocks with no transactions through RPC.