### PR TITLE
Fix precompile signature changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.26.0"
-source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#e3695a1c8ff6443ede36c4f3bfe80b9c7fb0ed22"
 dependencies = [
  "environmental",
  "ethereum",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.26.1"
-source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#e3695a1c8ff6443ede36c4f3bfe80b9c7fb0ed22"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.26.0"
-source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#e3695a1c8ff6443ede36c4f3bfe80b9c7fb0ed22"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.26.0"
-source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#e3695a1c8ff6443ede36c4f3bfe80b9c7fb0ed22"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,9 +1207,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1202e8dfa45bea73ee003c4be2f3549d60cb2e2ac5b0c1db563bd4653213efde"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
 dependencies = [
+ "environmental",
  "ethereum",
  "evm-core",
  "evm-gasometer",
@@ -1224,9 +1224,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeed00c943f6347108393c98907f432d8f2b82683725dfefbd734d335faace4"
+version = "0.26.1"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1237,9 +1236,9 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463412356790c5e34e8a13cd23ba06284d9afa999e82e8c64497aed2ee625375"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
 dependencies = [
+ "environmental",
  "evm-core",
  "evm-runtime",
  "primitive-types",
@@ -1248,9 +1247,9 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c08f510e5535cee2352adb9b93ff24dc80f8ca1bad445a9aa1292ce144b45a1"
+source = "git+https://github.com/PureStake/evm?branch=jeremy-environmental-hook#5dfb3bdaad8bff2e1242bb7a4a47a17fef30b095"
 dependencies = [
+ "environmental",
  "evm-core",
  "primitive-types",
  "sha3 0.8.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,12 @@ members = [
 	"template/runtime",
 	"template/test-utils/client",
 ]
+
+[patch.crates-io]
+# We use a custom EVM which support "environmental tracing". The patch allow to force usage of
+# this crate version in all transitive dependencies (frontier).
+# This will be necessary as long as frontier don't depend on this crate version.
+evm = { git = "https://github.com/PureStake/evm", branch = "jeremy-environmental-hook", default-features = false, features = ["with-codec", "tracing"] }
+evm-runtime = { git = "https://github.com/PureStake/evm", branch = "jeremy-environmental-hook", default-features = false, features = ["tracing"] }
+evm-core = { git = "https://github.com/PureStake/evm", branch = "jeremy-environmental-hook", default-features = false, features = ["with-codec", "tracing"] }
+evm-gasometer = { git = "https://github.com/PureStake/evm", branch = "jeremy-environmental-hook", default-features = false, features = ["tracing"] }

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -22,7 +22,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use fp_evm::Precompile;
-use evm::{ExitSucceed, ExitError, Context};
+use evm::{Context, ExitError, ExitSucceed, executor::PrecompileOutput};
 use frame_support::{dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo}, weights::{Pays, DispatchClass}};
 use pallet_evm::{AddressMapping, GasWeightMapping};
 use codec::Decode;
@@ -40,7 +40,7 @@ impl<T> Precompile for Dispatch<T> where
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-	) -> core::result::Result<(ExitSucceed, Vec<u8>, u64), ExitError> {
+	) -> core::result::Result<PrecompileOutput, ExitError> {
 		let call = T::Call::decode(&mut &input[..]).map_err(|_| ExitError::Other("decode failed".into()))?;
 		let info = call.get_dispatch_info();
 
@@ -61,7 +61,12 @@ impl<T> Precompile for Dispatch<T> where
 		match call.dispatch(Some(origin).into()) {
 			Ok(post_info) => {
 				let cost = T::GasWeightMapping::weight_to_gas(post_info.actual_weight.unwrap_or(info.weight));
-				Ok((ExitSucceed::Stopped, Default::default(), cost))
+				Ok(PrecompileOutput {
+					exit_status: ExitSucceed::Stopped,
+					cost,
+					output: Default::default(),
+					logs: Default::default(),
+				})
 			},
 			Err(_) => Err(ExitError::Other("dispatch execution failed".into())),
 		}

--- a/primitives/evm/src/precompile.rs
+++ b/primitives/evm/src/precompile.rs
@@ -18,7 +18,7 @@
 use sp_std::vec::Vec;
 use sp_core::H160;
 use impl_trait_for_tuples::impl_for_tuples;
-use evm::{ExitSucceed, ExitError, Context};
+use evm::{ExitSucceed, ExitError, Context, executor::PrecompileOutput};
 
 /// Custom precompiles to be used by EVM engine.
 pub trait PrecompileSet {
@@ -32,7 +32,7 @@ pub trait PrecompileSet {
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-	) -> Option<core::result::Result<(ExitSucceed, Vec<u8>, u64), ExitError>>;
+	) -> Option<core::result::Result<PrecompileOutput, ExitError>>;
 }
 
 /// One single precompile used by EVM engine.
@@ -44,7 +44,7 @@ pub trait Precompile {
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-	) -> core::result::Result<(ExitSucceed, Vec<u8>, u64), ExitError>;
+	) -> core::result::Result<PrecompileOutput, ExitError>;
 }
 
 #[impl_for_tuples(16)]
@@ -57,7 +57,7 @@ impl PrecompileSet for Tuple {
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-	) -> Option<core::result::Result<(ExitSucceed, Vec<u8>, u64), ExitError>> {
+	) -> Option<core::result::Result<PrecompileOutput, ExitError>> {
 		let mut index = 0;
 
 		for_tuples!( #(
@@ -86,11 +86,16 @@ impl<T: LinearCostPrecompile> Precompile for T {
 		input: &[u8],
 		target_gas: Option<u64>,
 		_: &Context,
-	) -> core::result::Result<(ExitSucceed, Vec<u8>, u64), ExitError> {
+	) -> core::result::Result<PrecompileOutput, ExitError> {
 		let cost = ensure_linear_cost(target_gas, input.len() as u64, T::BASE, T::WORD)?;
 
-		let (succeed, out) = T::execute(input, cost)?;
-		Ok((succeed, out, cost))
+		let (exit_status, output) = T::execute(input, cost)?;
+		Ok(PrecompileOutput {
+			exit_status,
+			cost,
+			output,
+			logs: Default::default(),
+		})
 	}
 }
 


### PR DESCRIPTION
The new EVM version containing the new hook system also contains a change of what is returned from a precompile.
This PR update all precompiles to use this new change.

> This PR used `jeremy-environmental-hook` EVM branch until it is merged in `master` / published on crates.io.