### PR TITLE
Versioned runtime fixes

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1674,6 +1674,17 @@ where
 		{
 			Some((hash, index)) => (hash, index as usize),
 			None => {
+				let api = self.client.runtime_api();
+				let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
+
+				let api_version =
+					if let Ok(Some(api_version)) = api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&best_block) {
+						api_version
+					} else {
+						return Err(internal_err(format!(
+							"failed to retrieve Runtime Api version"
+						)));
+					};
 				// If the transaction is not yet mapped in the frontier db,
 				// check for it in the transaction pool.
 				let mut xts: Vec<<B as BlockT>::Extrinsic> = Vec::new();
@@ -1696,14 +1707,21 @@ where
 						.collect::<Vec<<B as BlockT>::Extrinsic>>(),
 				);
 
-				let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
-				let ethereum_transactions: Vec<EthereumTransaction> = self
-					.client
-					.runtime_api()
-					.extrinsic_filter(&best_block, xts)
-					.map_err(|err| {
-						internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
-					})?;
+				let ethereum_transactions: Vec<EthereumTransaction> = if api_version > 1 {
+					api
+						.extrinsic_filter(&best_block, xts)
+						.map_err(|err| {
+							internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
+						})?
+				} else {
+					#[allow(deprecated)]
+					let legacy = api
+						.extrinsic_filter_before_version_2(&best_block, xts)
+						.map_err(|err| {
+							internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
+						})?;
+					legacy.into_iter().map(|tx| tx.into()).collect()
+				};
 
 				for txn in ethereum_transactions {
 					let inner_hash = txn.hash();

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1161,13 +1161,35 @@ where
 			}
 		};
 
+		let api_version =
+			if let Ok(Some(api_version)) = api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&id) {
+				api_version
+			} else {
+				return Err(internal_err(format!(
+					"failed to retrieve Runtime Api version"
+				)));
+			};
+
 		// use given gas limit or query current block's limit
 		let gas_limit = match gas {
 			Some(amount) => amount,
 			None => {
-				let block = api
-					.current_block(&id)
-					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+				let block = if api_version > 1 {
+					api
+						.current_block(&id)
+						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
+				} else {
+					#[allow(deprecated)]
+					let legacy_block = api
+						.current_block_before_version_2(&id)
+						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+					if let Some(block) = legacy_block {
+						Some(block.into())
+					} else {
+						None
+					}
+				};
+
 				if let Some(block) = block {
 					block.header.gas_limit
 				} else {
@@ -1178,15 +1200,6 @@ where
 			}
 		};
 		let data = data.map(|d| d.0).unwrap_or_default();
-
-		let api_version =
-			if let Ok(Some(api_version)) = api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&id) {
-				api_version
-			} else {
-				return Err(internal_err(format!(
-					"failed to retrieve Runtime Api version"
-				)));
-			};
 		match to {
 			Some(to) => {
 				if api_version == 1 {


### PR DESCRIPTION
- Use versioned `extrinsic_filter` on pending transactions rpc.
- Use versioned `current_block` in `eth_call` when no gas limit is specified.