### PR TITLE
feat(rpc): eth blocks cache: replace blocks limit by a byte size limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "lru 0.6.6",
  "pallet-ethereum",
  "parity-scale-codec",
+ "prometheus",
  "rand 0.8.4",
  "rlp",
  "sc-client-api",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -7,6 +7,7 @@ description = "Ethereum RPC (web3) compatibility layer for Substrate."
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0" }
 ethereum = { version = "0.11.1", features = ["with-codec"] }
 ethereum-types = "0.12"
 evm = "0.33.1"
@@ -18,12 +19,12 @@ lru = "0.6.6"
 jsonrpc-core = "18.0"
 jsonrpc-core-client = "18.0"
 jsonrpc-pubsub = "18.0"
+prometheus = { version = "0.13.0", default-features = false }
 rand = "0.8"
 rlp = "0.5"
 sha3 = "0.10"
 tokio = { version = "1.14", features = [ "sync" ] }
 
-codec = { package = "parity-scale-codec", version = "2.0.0" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint",  git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.17" }
 sp-api = { version = "4.0.0-dev",  git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.17" }
 sp-blockchain = { version = "4.0.0-dev",  git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.17" }

--- a/client/rpc/src/cache.rs
+++ b/client/rpc/src/cache.rs
@@ -1,0 +1,109 @@
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Frontier.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use codec::Encode;
+use lru::LruCache;
+
+pub struct LRUCacheByteLimited<K, V> {
+	cache: LruCache<K, V>,
+	max_size: u64,
+	metrics: Option<LRUCacheByteLimitedMetrics>,
+	size: u64,
+}
+
+impl<K: Eq + core::hash::Hash, V: Encode> LRUCacheByteLimited<K, V> {
+	pub fn new(
+		cache_name: &'static str,
+		max_size: u64,
+		prometheus_registry: Option<prometheus_endpoint::Registry>,
+	) -> Self {
+		let metrics = match prometheus_registry {
+			Some(registry) => match LRUCacheByteLimitedMetrics::register(cache_name, &registry) {
+				Ok(metrics) => Some(metrics),
+				Err(e) => {
+					log::error!(target: "eth-cache", "Failed to register metrics: {:?}", e);
+					None
+				}
+			},
+			None => None,
+		};
+
+		Self {
+			cache: LruCache::unbounded(),
+			max_size,
+			metrics,
+			size: 0,
+		}
+	}
+	pub fn get(&mut self, k: &K) -> Option<&V> {
+		self.cache.get(k)
+	}
+	pub fn put(&mut self, k: K, v: V) {
+		// Handle size limit
+		self.size += v.encoded_size() as u64;
+		if self.size > self.max_size {
+			let mut diff = self.size - self.max_size;
+			let keys_to_remove = self
+				.cache
+				.iter()
+				.rev()
+				.take_while(|(_k, v)| {
+					let v_size = v.encoded_size() as u64;
+					if diff > v_size {
+						diff -= v_size;
+						self.size -= v_size;
+						true
+					} else {
+						false
+					}
+				})
+				.map(|(k, _v)| k)
+				.collect::<Vec<_>>();
+			for key in keys_to_remove {
+				self.cache.pop(key);
+			}
+		}
+		// Add entry in cache
+		self.cache.put(k, v);
+		// Update metrics
+		if let Some(ref metrics) = self.metrics {
+			metrics
+				.size
+				.set(self.size.try_into().unwrap_or(std::u64::MAX));
+		}
+	}
+}
+
+struct LRUCacheByteLimitedMetrics {
+	size: prometheus_endpoint::Gauge<prometheus_endpoint::U64>,
+}
+
+impl LRUCacheByteLimitedMetrics {
+	pub(crate) fn register(
+		cache_name: &'static str,
+		registry: &prometheus_endpoint::Registry,
+	) -> std::result::Result<Self, prometheus_endpoint::PrometheusError> {
+		Ok(Self {
+			size: prometheus_endpoint::register(
+				prometheus_endpoint::Gauge::new(
+					format!("frontier_eth_{}_size", cache_name),
+					format!("Size of eth {} data cache.", cache_name),
+				)?,
+				registry,
+			)?,
+		})
+	}
+}

--- a/client/rpc/src/cache.rs
+++ b/client/rpc/src/cache.rs
@@ -55,15 +55,13 @@ impl<K: Eq + core::hash::Hash, V: Encode> LRUCacheByteLimited<K, V> {
 		// Handle size limit
 		self.size += v.encoded_size() as u64;
 		if self.size > self.max_size {
-			let mut diff = self.size - self.max_size;
 			let keys_to_remove = self
 				.cache
 				.iter()
 				.rev()
 				.take_while(|(_k, v)| {
-					let v_size = v.encoded_size() as u64;
-					if diff > v_size {
-						diff -= v_size;
+					if self.size > self.max_size {
+						let v_size = v.encoded_size() as u64;
 						self.size -= v_size;
 						true
 					} else {

--- a/client/rpc/src/cache.rs
+++ b/client/rpc/src/cache.rs
@@ -133,3 +133,24 @@ impl LRUCacheByteLimitedMetrics {
 		})
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_size_limit() {
+		let mut cache = LRUCacheByteLimited::new("name", 10, None);
+		cache.put(0, "abcd");
+		assert!(cache.get(&0).is_some());
+		cache.put(1, "efghij");
+		assert!(cache.get(&1).is_some());
+		cache.put(2, "k");
+		assert!(cache.get(&2).is_some());
+		// Entry (0,  "abcd") should be deleted
+		assert!(cache.get(&0).is_none());
+		// Size should be 7 now, so we should be able to add a value of size 3
+		cache.put(3, "lmn");
+		assert!(cache.get(&3).is_some());
+	}
+}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod cache;
 mod eth;
 mod eth_pubsub;
 mod overrides;
@@ -24,8 +25,8 @@ pub mod format;
 
 pub use self::{
 	eth::{
-		EthApi, EthApiServer, EthBlockDataCache, EthFilterApi, EthFilterApiServer, EthTask, NetApi,
-		NetApiServer, Web3Api, Web3ApiServer,
+		EthApi, EthApiServer, EthBlockDataCacheTask, EthFilterApi, EthFilterApiServer, EthTask,
+		NetApi, NetApiServer, Web3Api, Web3ApiServer,
 	},
 	eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider},
 	overrides::{
@@ -33,8 +34,8 @@ pub use self::{
 		SchemaV3Override, StorageOverride,
 	},
 };
-
 pub use ethereum::TransactionV2 as EthereumTransaction;
+
 use ethereum_types::{H160, H256};
 use evm::{ExitError, ExitReason};
 pub use fc_rpc_core::types::TransactionMessage;

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use fc_rpc::{
-	EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
+	EthBlockDataCacheTask, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
 	SchemaV2Override, SchemaV3Override, StorageOverride,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
@@ -57,7 +57,7 @@ pub struct FullDeps<C, P, A: ChainApi> {
 	/// Ethereum data access overrides.
 	pub overrides: Arc<OverrideHandle<Block>>,
 	/// Cache for Ethereum block data.
-	pub block_data_cache: Arc<EthBlockDataCache<Block>>,
+	pub block_data_cache: Arc<EthBlockDataCacheTask<Block>>,
 }
 
 pub fn overrides_handle<C, BE>(client: Arc<C>) -> Arc<OverrideHandle<Block>>

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -395,7 +395,7 @@ pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, Ser
 	let overrides = crate::rpc::overrides_handle(client.clone());
 	let fee_history_limit = cli.run.fee_history_limit;
 
-	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCache::new(
+	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
 		task_manager.spawn_handle(),
 		overrides.clone(),
 		50,


### PR DESCRIPTION
Ops need to be able to limit the cache by its size in number of bytes, not in number of blocks.
The size of a block being variable, ops sometimes have out of memory problems .

This PR also modifies and simplifies the metrics to provide only the cache size in bytes.
