### PR TITLE
[MOON-1489] return proper error when block number not on chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "lru 0.7.3",
+ "pallet-ethereum",
  "parity-scale-codec 3.1.2",
  "prometheus",
  "rand 0.8.5",
@@ -4158,6 +4159,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4350,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "libsecp256k1",
+ "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -45,6 +45,7 @@ use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_core::hashing::keccak_256;
+
 use sp_runtime::{
 	traits::{BlakeTwo256, Block as BlockT, NumberFor, One, Saturating, UniqueSaturatedInto, Zero},
 	transaction_validity::TransactionSource,
@@ -1214,6 +1215,13 @@ where
 				(id, api)
 			}
 		};
+
+		if let Ok(BlockStatus::Unknown) = self.client.status(id) {
+			return Err(internal_err(format!(
+				"failed to retrieve {}: not on chain",
+				id
+			)));
+		}
 
 		let api_version =
 			if let Ok(Some(api_version)) = api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&id) {

--- a/ts-tests/package-lock.json
+++ b/ts-tests/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ts-tests",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@types/chai": "^4.2.11",
         "@types/mocha": "^8.0.0",
         "chai": "^4.2.0",
+        "chai-as-promised": "^7.1.1",
         "ethers": "^5.4.6",
         "mocha": "^8.0.1",
         "mocha-steps": "^1.3.0",
@@ -19,6 +21,9 @@
         "ts-node": "^8.10.2",
         "typescript": "^3.9.6",
         "web3": "^1.3.4"
+      },
+      "devDependencies": {
+        "@types/chai-as-promised": "^7.1.5"
       }
     },
     "node_modules/@ethereumjs/common": {
@@ -781,6 +786,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
       "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
     },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.0.tgz",
@@ -1354,6 +1368,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -6435,6 +6460,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
       "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/mocha": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.0.tgz",
@@ -6898,6 +6932,14 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -13,13 +13,17 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "ethers": "^5.4.6",
     "mocha": "^8.0.1",
     "mocha-steps": "^1.3.0",
     "rimraf": "^3.0.2",
     "truffle": "^5.1.62",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.6",
-    "web3": "^1.3.4",
-    "ethers": "^5.4.6"
+    "web3": "^1.3.4"
+  },
+  "devDependencies": {
+    "@types/chai-as-promised": "^7.1.5"
   }
 }

--- a/ts-tests/tests/test-contract.ts
+++ b/ts-tests/tests/test-contract.ts
@@ -1,7 +1,10 @@
-import { expect } from "chai";
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
 
 import Test from "../build/contracts/Test.json"
 import { createAndFinalizeBlock, customRequest, describeWithFrontier } from "./util";
+
+chaiUse(chaiAsPromised);
 
 describeWithFrontier("Frontier RPC (Contract)", (context) => {
 	const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
@@ -50,8 +53,7 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 		expect(await customRequest(context.web3, "eth_getCode", [FIRST_CONTRACT_ADDRESS])).to.deep.equal({
 			id: 1,
 			jsonrpc: "2.0",
-			result:
-			TEST_CONTRACT_DEPLOYED_BYTECODE,
+			result: TEST_CONTRACT_DEPLOYED_BYTECODE,
 		});
 	});
 
@@ -59,5 +61,12 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 		expect(await context.web3.eth.call({
 			data: TEST_CONTRACT_BYTECODE
 		})).to.be.eq(TEST_CONTRACT_DEPLOYED_BYTECODE);
+	});
+
+	it("eth_call at missing block returns error", async function () {
+		const nonExistingBlockNumber = "999999";
+		await expect(context.web3.eth.call({
+			data: TEST_CONTRACT_BYTECODE,
+		}, nonExistingBlockNumber)).to.eventually.rejectedWith(`Returned error: failed to retrieve BlockId::Number(${nonExistingBlockNumber}): not on chain`);
 	});
 });


### PR DESCRIPTION
This fixes [MOON-1489](https://purestake.atlassian.net/browse/MOON-1489) where call an evm code at a non-existent block would lead to a confusing error.

Before: `Returned error: failed to retrieve Runtime Api version`

Now: `Returned error: failed to retrieve BlockId::Number(12345678): not on chain`