### PR TITLE
Avoid the stackoverflow during send_raw_transaction RPC call

### DIFF
--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -120,7 +120,7 @@ where
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 	A: ChainApi<Block = B> + 'static,
-	F: Send + Sync + 'static,
+	F: Formatter + Send + Sync + 'static,
 {
 	// ########################################################################
 	// Client


### PR DESCRIPTION
When users use the RPC call, send_raw_transaction, the node will encounter the StackOverflow issue in this branch. And the warning also indicates the recursive warnings during building.

```
warning: function cannot return without recursing
   --> client/rpc/src/eth/mod.rs:317:2
    |
317 |     fn send_raw_transaction(&self, bytes: Bytes) -> BoxFuture<'static, Result<H256>> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
318 |         self.send_raw_transaction(bytes)
    |         -------------------------------- recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose

```