### PR TITLE
Do not enter estimate mode when binary flag is enabled

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -572,6 +572,9 @@ where
 
 			// Verify that the transaction succeed with highest capacity
 			let cap = highest;
+			#[cfg(feature = "rpc_binary_search_estimate")]
+			let estimate_mode = false;
+			#[cfg(not(feature = "rpc_binary_search_estimate"))]
 			let estimate_mode = true;
 			let ExecutableResult {
 				data,


### PR DESCRIPTION
(cherry picked from commit 4729f69e506279e7312de62f84da25b7dcadf95b)