### PR TITLE
[MOON-2268] skip eip-3607 transaction verification for internal calls

### DIFF
--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -572,8 +572,8 @@ fn eip3607_transaction_from_contract_should_fail() {
 			None,
 			None,
 			Vec::new(),
-			false, // non-transactional
-			true,  // must be validated
+			true,  // transactional
+			false, // may not be validated
 			&<Test as Config>::config().clone(),
 		) {
 			Err(RunnerError {
@@ -582,6 +582,29 @@ fn eip3607_transaction_from_contract_should_fail() {
 			}) => (),
 			_ => panic!("Should have failed"),
 		}
+	});
+}
+
+#[test]
+fn eip3607_non_transaction_from_contract_should_succeed() {
+	new_test_ext().execute_with(|| {
+		let r = <Test as Config>::Runner::call(
+			// Contract address.
+			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			Vec::new(),
+			U256::from(1u32),
+			1000000,
+			None,
+			None,
+			None,
+			Vec::new(),
+			false, // non-transactional
+			true,  // must be validated
+			&<Test as Config>::config().clone(),
+		);
+
+		assert!(r.is_ok());
 	});
 }
 
@@ -599,8 +622,8 @@ fn eip3607_transaction_from_precompile_should_fail() {
 			None,
 			None,
 			Vec::new(),
-			false, // non-transactional
-			true,  // must be validated
+			true, 	// transactional
+			false,  // may be validated
 			&<Test as Config>::config().clone(),
 		) {
 			Err(RunnerError {
@@ -609,5 +632,28 @@ fn eip3607_transaction_from_precompile_should_fail() {
 			}) => (),
 			_ => panic!("Should have failed"),
 		}
+	});
+}
+
+#[test]
+fn eip3607_non_transaction_from_precompile_should_succeed() {
+	new_test_ext().execute_with(|| {
+		let r = <Test as Config>::Runner::call(
+			// Precompile address.
+			H160::from_str("0000000000000000000000000000000000000001").unwrap(),
+			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			Vec::new(),
+			U256::from(1u32),
+			1000000,
+			None,
+			None,
+			None,
+			Vec::new(),
+			false, // non-transactional
+			true,  // must be validated
+			&<Test as Config>::config().clone(),
+		);
+
+		assert!(r.is_ok());
 	});
 }

--- a/ts-tests/tests/test-eth-call.ts
+++ b/ts-tests/tests/test-eth-call.ts
@@ -1,0 +1,77 @@
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import Web3 from "web3";
+import { Contract } from "web3-eth-contract";
+import { AbiItem } from "web3-utils";
+
+import Test from "../build/contracts/Test.json";
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
+import { createAndFinalizeBlock, customRequest, describeWithFrontier } from "./util";
+
+chaiUse(chaiAsPromised);
+
+async function deployContract(
+	web3: Web3,
+	bytecode: string,
+	abi: AbiItem[]
+): Promise<{
+	contract: Contract;
+	contractAddress: string;
+}> {
+	const contract = new web3.eth.Contract(abi);
+	const data = contract.deploy({ data: bytecode }).encodeABI();
+	const tx = await web3.eth.accounts.signTransaction(
+		{
+			from: GENESIS_ACCOUNT,
+			data,
+			value: "0x00",
+			gas: "0x100000",
+		},
+		GENESIS_ACCOUNT_PRIVATE_KEY
+	);
+	const { result } = await customRequest(web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+	await createAndFinalizeBlock(web3);
+	const receipt = await web3.eth.getTransactionReceipt(result);
+	const contractAddress = receipt.contractAddress;
+
+	return { contract, contractAddress };
+}
+
+describeWithFrontier("Frontier RPC (EthCall)", (context) => {
+	let contract: Contract;
+	let contractAddress: string;
+	let contractAddress2: string;
+
+	before("deploy contract to two addresses", async function () {
+		this.timeout(15000);
+		const firstDeploy = await deployContract(context.web3, Test.bytecode, Test.abi as AbiItem[]);
+		const secondDeploy = await deployContract(context.web3, Test.bytecode, Test.abi as AbiItem[]);
+		contract = firstDeploy.contract;
+		contractAddress = firstDeploy.contractAddress;
+		contractAddress2 = secondDeploy.contractAddress;
+	});
+
+	it("should be able to call eth_call from address with no code", async function () {
+		const r = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.multiply(5).encodeABI(),
+			},
+		]);
+		expect(r.error?.message).to.be.undefined;
+		expect(Web3.utils.hexToNumberString(r.result)).to.equal("35");
+	});
+
+	it("should be able to call eth_call from address with code", async function () {
+		const r = await customRequest(context.web3, "eth_call", [
+			{
+				from: contractAddress2,
+				to: contractAddress,
+				data: await contract.methods.multiply(5).encodeABI(),
+			},
+		]);
+		expect(r.error?.message).to.be.undefined;
+		expect(Web3.utils.hexToNumberString(r.result)).to.equal("35");
+	});
+});


### PR DESCRIPTION
skips eip-3607 transaction verification for internal calls like `eth_call`

Upstream PR pending https://github.com/paritytech/frontier/pull/1018